### PR TITLE
Add frontend audit and 2030 roadmap docs

### DIFF
--- a/NEXT_STEPS_2030.md
+++ b/NEXT_STEPS_2030.md
@@ -1,0 +1,25 @@
+# 2030-Readiness Roadmap (Frontend)
+
+1. **Zero-trust authentication & secret handling**
+   - Remove client-embedded secrets; adopt PKCE/OAuth device flows with backend-issued short-lived tokens and refresh rotation managed server-side. Drive auth state via secure cookies or WebAuthn/MFA-first UX aligned with backend’s asymmetric JWT strategy.
+   - Add centralized auth guard + interceptor that handles token refresh, idle timeout, and 401 recovery, with secure storage abstractions and CSP/Trusted Types for XSS defense.
+
+2. **Framework modernization & accessibility**
+   - Upgrade to the latest LTS Angular (standalone components, signals, Angular CLI/ESBuild) and migrate from TSLint to ESLint + strict TypeScript settings. Replace legacy jQuery/AdminLTE dependencies with Angular Material/CDK or design-system components that meet WCAG 2.2 AA.
+   - Add full i18n/l10n support (Angular i18n or Transloco), RTL readiness, and comprehensive a11y testing (axe, pa11y) to match backend’s user-trust goals.
+
+3. **Observability, resilience, and API alignment**
+   - Generate typed API clients from OpenAPI specs exposed by the backend gateway, enforce request/response schemas, and instrument network calls with structured logging/metrics (e.g., OpenTelemetry web tracer + backend tracing).
+   - Add offline/readiness states with retry/backoff, circuit breakers for media uploads/notifications, and UX fallbacks consistent with backend health probes and rate limits.
+
+4. **Performance & delivery**
+   - Adopt modern build targets (ES2022/ESM), differential loading, image optimization, and CDN-backed asset delivery; enable route-level code splitting and prefetching for core flows.
+   - Implement real user monitoring (Core Web Vitals dashboards), synthetic checks, and performance budgets in CI/CD. Add PWA features (service worker caching, background sync) for resilient mobile/desktop experiences.
+
+5. **Secure collaboration & compliance**
+   - Introduce content-safety tooling (profanity/abuse filters) and privacy controls (data export/delete flows) in the UI, mirroring backend compliance hooks.
+   - Embed privacy notices/consent banners, granular notification settings, and audit-friendly UX for sensitive actions; ensure cookie consent aligns with backend telemetry and data retention policies.
+
+6. **Developer experience & testing**
+   - Standardize on Nx or an Angular workspace with lint/test/format pipelines (ESLint, Jest/Karma replacement, Playwright/Cypress for e2e) and story-driven UI docs (Storybook) to shorten feedback loops.
+   - Add contract tests against mock servers/Testcontainers-backed environments, seed data-driven visual regression tests, and security scanning (SCA + dependency review) in CI/CD to keep parity with backend delivery practices.

--- a/REPO_ISSUES.md
+++ b/REPO_ISSUES.md
@@ -1,0 +1,20 @@
+# Repository Audit Findings (Frontend)
+
+## Security and secrets management
+- **Sensitive OAuth credentials committed to source**: Google client ID/secret and Facebook app ID are hardcoded in the development environment file, exposing confidential values and preventing environment-based rotation. Replace with environment-variable driven configuration and omit secrets from the client bundle; use backend OAuth flows or PKCE where applicable.【F:src/environments/environment.ts†L5-L15】
+- **Bearer token handling via sessionStorage with no expiry/refresh safeguards**: The token interceptor unconditionally reads a token from `sessionStorage` and forwards it without expiry checks, refresh workflows, or CSRF/XSS protections. Move to secure, HTTP-only cookies or a hardened storage strategy, add refresh token flows, and centralize auth state management with interceptors that handle expiration gracefully.【F:src/app/interceptors/token-interceptor.service.ts†L13-L25】
+
+## Configuration and build hygiene
+- **Outdated Angular/NativeScript stack**: The project is pinned to Angular 11/TypeScript 4.0 with deprecated TSLint and legacy NativeScript dependencies, exposing the app to EOL security issues and tooling gaps. Upgrade to current LTS Angular versions, replace TSLint with ESLint, and modernize NativeScript or decouple mobile code paths as needed.【F:package.json†L2-L75】
+- **Production environment lacks required settings**: `environment.prod.ts` omits API base URLs and third-party configuration, risking broken builds or accidental use of development settings in production bundles. Define full production-safe configuration and ensure Angular file replacements are aligned with deployment targets.【F:src/environments/environment.prod.ts†L1-L3】
+
+## Code quality and correctness
+- **HTTP interceptor lacks interface implementation and strong typing**: `LoggingInterceptorService` omits `HttpInterceptor` implementation and uses loosely typed methods, reducing compile-time checks and making DI ordering harder to reason about. Implement `HttpInterceptor`, type the request/response streams, and rely on Angular’s logging/observability hooks instead of ad-hoc message arrays.【F:src/app/interceptors/logging-interceptor.service.ts†L1-L34】
+- **Service methods drop observables and leak debug output**: `sendVerificationCode` never returns the HTTP observable, preventing callers from subscribing or handling errors; `updateUser` still includes console logging. Return the request observable and remove console noise in favor of centralized logging and UI feedback channels.【F:src/app/service/user.service.ts†L12-L85】
+- **Dead/unused request parameters**: `findUser`/`findEmail` create `HttpParams` that are never applied, leading to misleading code and potential caching/proxy issues. Remove unused params or correctly attach them to requests with explicit pagination and debouncing strategies.【F:src/app/service/user.service.ts†L47-L56】
+
+## UX/Performance consistency
+- **Heavy jQuery/AdminLTE globals inside Angular module**: Global imports of AdminLTE/jQuery assets directly in `AppModule` increase bundle size and risk DOM conflicts with Angular’s renderer. Prefer Angular-friendly UI libraries or lazy-loaded modules, and gate legacy assets behind feature modules or build-time optimization.【F:src/app/app.module.ts†L8-L111】
+
+## Alignment with backend roadmap
+- **Front-end lacks parity with backend security/observability upgrades**: The backend roadmap calls for structured logging, OAuth hardening, and modern authentication flows. The frontend should mirror these by adopting structured client-side logging, OpenAPI-driven client generation, MFA-ready UX, and accessibility/localization foundations to maintain end-to-end consistency.


### PR DESCRIPTION
## Summary
- add REPO_ISSUES.md capturing current frontend audit findings
- add NEXT_STEPS_2030.md outlining a 2030-ready roadmap aligned with backend guidance

## Testing
- not run (documentation-only change)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692d1244a7f48328a5edcaa36f0042e9)